### PR TITLE
Overhaul how we handle embvm RTOS headers

### DIFF
--- a/include/c++/external_threading/__external_threading_framework
+++ b/include/c++/external_threading/__external_threading_framework
@@ -1,9 +1,9 @@
 #ifndef _FRAMEWORK_EXTERNAL_THREADING
 #define _FRAMEWORK_EXTERNAL_THREADING
 
-#include <rtos/rtos_defs.hpp>
 #include <__config>
 #include <chrono>
+#include <cstdint>
 
 #ifndef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
 #pragma GCC system_header
@@ -26,6 +26,13 @@ _LIBCPP_PUSH_MACROS
 #define _LIBCPP_NO_THREAD_SAFETY_ANALYSIS
 #endif
 
+// Forward declare Embedded VM interface classes BEFORE std namespace begins
+namespace embvm {
+	class VirtualMutex;
+	class VirtualConditionVariable;
+	class VirtualThread;
+}
+
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 // Mutex
@@ -47,7 +54,7 @@ typedef uintptr_t __libcpp_exec_once_flag;
 #endif
 
 // Thread id
-typedef embvm::thread::handle_t __libcpp_thread_id;
+typedef uintptr_t __libcpp_thread_id;
 
 // Thread
 #define _LIBCPP_NULL_THREAD 0U
@@ -60,7 +67,7 @@ typedef ::timespec __libcpp_timespec_t;
 #if defined(_LIBCPP_FRAMEWORK_FORCE_PTHREAD)
 typedef pthread_key_t __libcpp_tls_key;
 #else
-typedef embvm::tls::handle_t __libcpp_tls_key;
+typedef uintptr_t __libcpp_tls_key;
 #endif
 
 #define _LIBCPP_TLS_DESTRUCTOR_CC

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,6 @@ enable_monotonic_clock = get_option('libcxx-monotonic-clock')
 force_32_bit = get_option('force-32-bit')
 enable_chrono = get_option('libcxx-enable-chrono')
 thread_library = get_option('libcxx-thread-library')
-os_header_path = get_option('os-header-path')
 use_external_libc = get_option('use-libc-subproject')
 
 # The default terminate handler attempts to demangle uncaught exceptions, which
@@ -502,14 +501,9 @@ if enable_threads == true
 	elif thread_library == 'ea-framework'
 		# If we aren't using pthreads, use an external header
 		message('Building with framework thread library support')
-		message('Using include path to core RTOS headers: ' + os_header_path)
+
 		libcxx_conf_data.set('_LIBCPP_HAS_THREAD_API_EXTERNAL', true)
-
-		libcxxabi_include_directories += include_directories(os_header_path, is_system: true)
-		libcxx_include_directories += include_directories(os_header_path, is_system: true)
-
 		libcpp_core_files += files('src/c++/thread.cpp')
-
 		using_pthread = true
 	else
 		# If we aren't using pthreads or framework, use an external header
@@ -522,13 +516,6 @@ if enable_threads == true
 		else
 			libcxx_conf_data.set('_LIBCPP_HAS_THREAD_API_EXTERNAL', true)
 			libcpp_core_files += files('src/c++/thread.cpp')
-		endif
-
-		if os_header_path == ''
-			message('If the build fails, please set os-header-path so the build can find your includes')
-		else
-			libcxxabi_include_directories += include_directories(os_header_path, is_system: true)
-			libcxx_include_directories += include_directories(os_header_path, is_system: true)
 		endif
 
 		# TODO: test - does the new logic break in this case, and should we reactivate this?

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,3 @@
-option('os-header-path', type: 'string', value: '../embvm-core/src/core', yield: true)
 option('force-32-bit', type: 'boolean', value: false, yield: true,
     description: 'Force 32-bit compilation for libcpp')
 option('disable-rtti', type : 'boolean', value: false, yield: true)


### PR DESCRIPTION
Including rtos_defs.hpp is problematic because we need to know about embvm-core, which creates a subproject race condition with our builds.

Instead, we'll forward declare everything we need, breaking the header dep.
