### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,8 @@
 	url = git@github.com:llvm-mirror/libcxx.git
 [submodule "build"]
 	path = meson
-	url = https://github.com/embeddedartistry/meson-buildsystem[submodule "embedded-unwind"]
+	url = https://github.com/embeddedartistry/meson-buildsystem
+[submodule "embedded-unwind"]
 	path = embedded-unwind
 	url = git@github.com:embeddedartistry/embedded-unwind.git
 [submodule "extensions/plf_list"]


### PR DESCRIPTION
fixed a missing line break, that was causing this library to not properly build

## Description

It seems that there was a line break that was accidentally deleted from the .gitmodules file.

When I was trying to build a skeleton project, I was getting the following error:

```bash
fatal: No url found for submodule path 'meson' in .gitmodules

meson.build:1:0: ERROR: Git command failed: ['/opt/homebrew/bin/git', 'submodule', 'update', '--init', '--checkout', '--recursive']
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
